### PR TITLE
Improve naming of output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@
 
 # MacOS
 .DS_Store
+
+# Generator output
+/*.pem
+/*.key
+*.srl

--- a/issue-cert.sh
+++ b/issue-cert.sh
@@ -2,8 +2,8 @@
 NETWORK=$1
 HOST=$2
 echo Generating key and certificate for $HOST to join $NETWORK
-openssl ecparam -genkey -name prime256v1 -noout -out $HOST.key
-openssl req -new -key $HOST.key -out $HOST.csr -subj "/CN=${HOST}"
+openssl ecparam -genkey -name prime256v1 -noout -out $HOST-$NETWORK.key
+openssl req -new -key $HOST-$NETWORK.key -out $HOST-$NETWORK.csr -subj "/CN=${HOST}"
 
 local_openssl_config="
 authorityKeyIdentifier=keyid,issuer
@@ -15,9 +15,11 @@ extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = DNS:${HOST}
 "
 cat <<< "$local_openssl_config" > node.ext
-openssl x509 -req -in $HOST.csr -CA $NETWORK/ca.pem -CAkey $NETWORK/ca.key -CAcreateserial -out $HOST.pem -days 365 -sha256 \
+openssl x509 -req -in $HOST-$NETWORK.csr -CA $NETWORK/ca.pem -CAkey $NETWORK/ca.key -CAcreateserial -out $HOST-$NETWORK.pem -days 365 -sha256 \
   -extfile node.ext \
   -extensions alt_names
 
-rm $HOST.csr
+cp $NETWORK/ca.pem truststore-$NETWORK.pem
+
+rm $HOST-$NETWORK.csr
 rm node.ext


### PR DESCRIPTION
Append network name to the generated cert and key files.
Also copy the ca.pem to the root so it is clear the $NETWORK/ca.pem can be used as truststore.