### PR TITLE
removed parameter & unused config.

### DIFF
--- a/issue-cert.sh
+++ b/issue-cert.sh
@@ -15,9 +15,6 @@ fi
 openssl req -new -key $HOST-$NETWORK.key -out $HOST-$NETWORK.csr -subj "${DN_PREFIX}CN=${HOST}"
 
 local_openssl_config="
-authorityKeyIdentifier=keyid,issuer
-basicConstraints=CA:FALSE
-keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
 extendedKeyUsage = serverAuth, clientAuth
 
 [alt_names]
@@ -25,8 +22,7 @@ subjectAltName = DNS:${HOST}
 "
 cat <<< "$local_openssl_config" > node.ext
 openssl x509 -req -in $HOST-$NETWORK.csr -CA $NETWORK/ca.pem -CAkey $NETWORK/ca.key -CAcreateserial -out $HOST-$NETWORK.pem -days 365 -sha256 \
-  -extfile node.ext \
-  -extensions alt_names
+  -extfile node.ext
 
 cp $NETWORK/ca.pem truststore-$NETWORK.pem
 

--- a/issue-cert.sh
+++ b/issue-cert.sh
@@ -16,6 +16,7 @@ openssl req -new -key $HOST-$NETWORK.key -out $HOST-$NETWORK.csr -subj "${DN_PRE
 
 local_openssl_config="
 extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = DNS:${HOST}
 
 [alt_names]
 subjectAltName = DNS:${HOST}


### PR DESCRIPTION
We now have a use case where we want to add a generated certificate to an Azure Appservice. One of the requirements of an certificate to be used on an Azure Appservice  is that it has to have the "extendedKeyUsage = serverAuth". In the master version it looks like this is added in the config, nothing except for the altnames is used however because of the "-extensions alt_names" parameter passed to the generation script.

With this change the config values which presumably weren't used anyway were removed for clarity, only keeping the extendedKeyUsage and the "-extensions alt_names" parameter was removed so the whole defined config actually gets read/used.