### PR TITLE
Generate v3 CA certificate instead of v1

### DIFF
--- a/development/generate.sh
+++ b/development/generate.sh
@@ -1,8 +1,18 @@
+#!/bin/bash
+
 if [[ $OSTYPE == msys ]]; then
   echo Script does not work on GitBash/Cygwin!
   exit 1
 fi
 
+CONFIG="
+[req]
+distinguished_name=dn
+[ dn ]
+[ ext ]
+basicConstraints=CA:TRUE,pathlen:0
+"
+
 echo Generating development network root CA
 openssl ecparam -genkey -name prime256v1 -noout -out ca.key
-openssl req -x509 -new -nodes -key ca.key -sha256 -days 1825 -out ca.pem -subj "/CN=Nuts Development Network Root CA"
+openssl req -config <(echo "$CONFIG") -extensions ext -x509 -new -nodes -key ca.key -sha256 -days 1825 -out ca.pem -subj "/CN=Nuts Development Network Root CA"

--- a/stable/generate.sh
+++ b/stable/generate.sh
@@ -1,8 +1,18 @@
+#!/bin/bash
+
 if [[ $OSTYPE == msys ]]; then
   echo Script does not work on GitBash/Cygwin!
   exit 1
 fi
 
+CONFIG="
+[req]
+distinguished_name=dn
+[ dn ]
+[ ext ]
+basicConstraints=CA:TRUE,pathlen:0
+"
+
 echo Generating stable network root CA
 openssl ecparam -genkey -name prime256v1 -noout -out ca.key
-openssl req -x509 -new -nodes -key ca.key -sha256 -days 1825 -out ca.pem -subj "/CN=Nuts Stable Development Network Root CA"
+openssl req -config <(echo "$CONFIG") -extensions ext -x509 -new -nodes -key ca.key -sha256 -days 1825 -out ca.pem -subj "/CN=Nuts Stable Development Network Root CA"


### PR DESCRIPTION
v1 certificates don't support, thus don't support `basicConstrans: IsCA`. Using v3 is more according to real-world usage.
Will take effect when we generate new dev/stable root CA.

Previous cert:

```
openssl x509 -inform pem -text -in ca.pem
Certificate:
    Data:
        Version: 1 (0x0)
        Serial Number: 13350982867869940166 (0xb948382e89b6b9c6)
    Signature Algorithm: ecdsa-with-SHA256
        Issuer: CN=Nuts Development Network Root CA
        Validity
            Not Before: Nov  3 12:36:18 2022 GMT
            Not After : Nov  2 12:36:18 2027 GMT
        Subject: CN=Nuts Development Network Root CA
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:1d:de:76:9c:43:1a:39:ce:b1:6f:36:a9:8e:65:
                    b2:c7:2e:fa:f3:44:8e:fe:39:e1:18:d8:a0:ab:0b:
                    8a:64:f1:b1:7e:aa:82:f8:4f:bf:d7:c4:1e:2b:44:
                    ec:ee:da:1a:15:f9:b6:ca:dc:c0:b2:fe:14:97:eb:
                    83:c3:ec:f5:4d
                ASN1 OID: prime256v1
                NIST CURVE: P-256
    Signature Algorithm: ecdsa-with-SHA256
         30:44:02:20:2b:0e:e1:55:51:38:8b:40:d9:24:59:fe:d7:13:
         e1:0a:48:58:4b:93:51:39:3a:4d:7c:8d:44:df:ca:ce:0f:1b:
         02:20:7e:20:fe:4c:8c:b9:3f:66:06:5d:08:ce:f1:9e:ff:89:
         ed:82:c1:61:f5:cf:30:54:70:02:a3:1b:d6:3e:8b:3e
```

New cert (note `pathlen=0`, disallowing intermediate CAs):

```
openssl x509 -inform pem -text -in ca.pem
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 10689166856025023900 (0x94578c9f3640259c)
    Signature Algorithm: ecdsa-with-SHA256
        Issuer: CN=Nuts Development Network Root CA
        Validity
            Not Before: Nov  3 12:36:42 2022 GMT
            Not After : Nov  2 12:36:42 2027 GMT
        Subject: CN=Nuts Development Network Root CA
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:bf:75:40:11:ea:28:d9:ea:9a:72:58:0d:e6:60:
                    fd:16:5c:85:a1:84:c0:a7:de:5c:64:82:a2:7a:e5:
                    e5:2a:30:66:a8:f7:84:b9:cf:88:76:6a:3b:2b:80:
                    f0:dd:c2:54:bc:6b:d5:d3:a0:34:cf:f9:d5:7e:13:
                    39:e8:61:01:ea
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Basic Constraints:
                CA:TRUE, pathlen:0
    Signature Algorithm: ecdsa-with-SHA256
         30:45:02:20:03:67:49:05:29:fb:6c:8d:27:99:5d:85:a2:a7:
         b1:ba:6c:40:83:88:f1:91:08:f5:97:dd:d6:c3:d1:c2:2b:b8:
         02:21:00:dc:5a:05:35:91:6c:68:eb:1a:12:b3:13:17:13:f6:
         98:9a:63:b1:da:b6:71:bd:d4:23:ad:14:b9:98:6d:aa:3a
```